### PR TITLE
Fix Deprecation Warnings for CFB mode and Camellia ciphers, by importing from cryptography.hazmat.decrepit

### DIFF
--- a/tlexport/cipher_suite_parser.py
+++ b/tlexport/cipher_suite_parser.py
@@ -9,6 +9,8 @@ with warnings.catch_warnings():
     from cryptography.hazmat.primitives.ciphers import modes
     from cryptography.hazmat.primitives.ciphers.algorithms import AES, TripleDES, Camellia, IDEA, ARC4, ChaCha20
     from cryptography.hazmat.primitives.ciphers import aead
+    from cryptography.hazmat.decrepit.ciphers import modes as decrepit_modes
+
 
 cipher_suites = {
     # The following 5 cipher suites are the only cipher suites supported by TLSv1.3
@@ -280,7 +282,7 @@ cipher_suite_parts = {
     },
 
     "Mode": {
-        "CBC": (modes.CBC, 0),  # Tuple[0] is the mode and Tuple[1] is 1 if mode uses AEAD, else it is 0
+        "CBC": (decrepit_modes.CBC, 0),  # Tuple[0] is the mode and Tuple[1] is 1 if mode uses AEAD, else it is 0
         "CFB": (modes.CFB, 0),
         "CTR": (modes.CTR, 0),
         "GCM": (modes.GCM, 1),

--- a/tlexport/key_derivator.py
+++ b/tlexport/key_derivator.py
@@ -5,6 +5,7 @@ from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand, HKDF
+from cryptography.hazmat.decrepit.ciphers import algorithms as decrepit_algorithms
 
 
 def dev_ssl_30_keys(master_secret, server_random, client_random, key_length, mac_length, key_block_length, cipher_algo,
@@ -79,9 +80,9 @@ def dev_tls_12_keys(master_secret, client_random, server_random, key_length, mac
     if cipher_algo == ChaCha20Poly1305:
         iv_length = 12
 
-    if cipher_algo in [algorithms.AES, algorithms.Camellia]:
+    if cipher_algo in [algorithms.AES, decrepit_algorithms.Camellia]:
         iv_length = 16
-        if cipher_algo == algorithms.Camellia and use_aead:
+        if cipher_algo == decrepit_algorithms.Camellia and use_aead:
             iv_length = 4
 
     if use_aead:


### PR DESCRIPTION
Pull request to fix #4 . Please let me know if there is more that I need to do.